### PR TITLE
Use upn for "Logged in as …" message

### DIFF
--- a/extension/login.js
+++ b/extension/login.js
@@ -11,7 +11,7 @@ window.addEventListener("load", function(event) {
 		console.log("Sending login info.")
 		var email = null;
 		if (keycloak.idTokenParsed) {
-			email = keycloak.idTokenParsed.email;
+			email = keycloak.idTokenParsed.upn;
 		}
 		chrome.runtime.sendMessage({
 			'message' : 'recheck-web_login',


### PR DESCRIPTION
The pop-up window showing what is going on would show "Logged in as undefined.", after using the field `upn` everything works again as expected.