### PR TITLE
Add mergify config from retest/recheck

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,35 @@
+pull_request_rules:
+  - name: "rebase unreviewed non-release PRs"
+    conditions:
+      - "head~=^(?!(release|hotfix)).*$"
+      - "#approved-reviews-by=0"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      rebase: {}
+
+  - name: "merge non-release PRs with strict rebase"
+    conditions:
+      - "head~=^(?!(release|hotfix)).*$"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      merge:
+        strict: true
+        strict_method: rebase
+        method: merge
+
+  - name: "merge release PRs with strict merge"
+    conditions:
+      - "head~=^(release|hotfix).*$"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      merge:
+        strict: true
+        method: merge
+
+  - name: "delete PR branches after merge"
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}


### PR DESCRIPTION
This is copied from retest/recheck/.mergify.yaml

This PR needs to be merged manually, after that, simply comment with `@Mergifyio refresh` on existing PRs. From that point on, mergify should do that on its own.